### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install required dependencies
+        run: sudo apt-get update && sudo apt-get install -y libssl1.1
+
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
The error indicates that the dotnet build command failed due to a missing or incompatible version of libssl. This is a common issue when running .NET applications on Linux-based environments, as .NET requires specific versions of libssl to function properly. Steps to Resolve the Issue:
1.	Update the Workflow to Install the Required libssl Version: Modify your workflow file to include a step that installs the correct version of libssl. For .NET 9, the required version is typically libssl1.1 or libssl3.